### PR TITLE
Modify model for ONNX compatibility

### DIFF
--- a/kokoro/istftnet.py
+++ b/kokoro/istftnet.py
@@ -23,7 +23,8 @@ def get_padding(kernel_size, dilation=1):
 class AdaIN1d(nn.Module):
     def __init__(self, style_dim, num_features):
         super().__init__()
-        self.norm = nn.InstanceNorm1d(num_features, affine=False)
+        # affine should be False, however there's a bug in the old torch.onnx.export (not newer dynamo) that causes the channel dimension to be lost if affine=False. When affine is true, there's additional learnably parameters. This shouldn't really matter setting it to True, since we're in inference mode
+        self.norm = nn.InstanceNorm1d(num_features, affine=True)
         self.fc = nn.Linear(style_dim, num_features*2)
 
     def forward(self, x, s):


### PR DESCRIPTION
This change implements fixes to allow exporting to ONNX from torch. I'm working on adding export scripts in a sibling repo at https://github.com/adrianlyjak/kokoro-onnx-export. I'm aware that there's ONNX models exported and shared on hugging face from taylorchu (github: https://github.com/taylorchu/kokoro-onnx, huggingface https://huggingface.co/onnx-community/Kokoro-82M-ONNX), but it seems like the export process hasn't been shared. I've been curious about learning more about the model, and learning about ONNX, so took a stab at this.

Not sure if you're interested in the changes here, or have any reservations about performance degradation or other such (not sure how the changes to the AdaIN1d might affect performance?). From what I can see, the vast majority of time and parameters is spent on the convolutions, so it doesn't seem like a significant change.

Summary of changes:

Simple fixes:
- removes usages of numpy conversions
- removes device `.to` movement, instead initializing tensors on the correct device from the start

Moderate fixes:
- modifies/inlines normalization in AdaIN1d. Not entirely sure whether this is necessary for all code paths, but this fixes an issue with the layer when inputs were directly taken from an LSTM output
- modifies a permute call to remove a negative index, which was throwing off the onnx export 🤷 
- refactors the KModel interface, such that there's a good entrypoint for ONNX export to trace, that does not include the tokenization

Complicated fixes:
- Torch is moving towards using the dynamo backend for onnx exports. There's a bit of a catch 22 in torch onnx export functionality: dynamo based exports lack support for LSTM layers, which there are a number of, however it supports complex numbers, which the `TorchSTFT` uses. I was considering making a process to export parts of the model with the dynamo based export, and the other without, and gluing them together. However, the STFT was not too difficult to rewrite (I'm a little over my head here, this was mostly written by OpenAI o1), so I opted for that instead, and made this component optional to the onnx export only